### PR TITLE
Fix platformio library for ARM chips

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -1,7 +1,24 @@
 Import('env')
-from os.path import join, realpath
+from os.path import join, realpath, exists
 
-env.Append(
-    LIBPATH=[realpath(join('src', env.get('BOARD_MCU')))],
-    LIBS=['algobsec']
-)
+# We need the equivalent of build.mcu in Arduino board definitions. 
+# For ESP this is BOARD_MCU
+cpu = env.get("BOARD_MCU")
+
+# For ARM cores, BOARD_MCU is the chip (e.g. rp2040), not the cpu (e.g. cortex-m0plus).
+# To find the correct binary, we check the linkflags.
+linkflags = env.get("LINKFLAGS", [])
+for flag in linkflags:
+    if flag.startswith("-mcpu="):
+        prefix, divider, cpu = flag.partition("=")
+        continue
+
+path = realpath(join("src", cpu))
+if exists(path):
+    env.Append(
+        LIBPATH=[realpath(join("src", cpu))],
+        LIBS=["algobsec"]
+    )
+else:
+    print(f"BSEC2 is not supported for CPU '{cpu}', path '{path}' doesn't exist")
+    exit(1)


### PR DESCRIPTION
When using e.g. a Raspberry Pi Pico or ATMEL SAM, BOARD_MCU is 'rp2040' or 'samd21e18a', not 'cortex-m0plus'.

* Parse CPU from linker flags, if flag is set (Unfortunately the CPU is only available in env as linker or compiler flag)
* Return error message if no folder for CPU exists in library