### PR TITLE
Use esp32c3 build for all riscv ESPs

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -5,6 +5,10 @@ from os.path import join, realpath, exists
 # For ESP this is BOARD_MCU
 cpu = env.get("BOARD_MCU")
 
+#All ESP32 except the original and S-series use riscv cores. Can use ESP32-C3 build.
+if len(cpu) > 5 and cpu[:5] == "esp32" and cpu[5] != "s":
+    cpu = "esp32c3"
+
 # For ARM cores, BOARD_MCU is the chip (e.g. rp2040), not the cpu (e.g. cortex-m0plus).
 # To find the correct binary, we check the linkflags.
 linkflags = env.get("LINKFLAGS", [])


### PR DESCRIPTION
This allows to use bsec2 with all new esp32 variants that are risc-v based: C2, C3, C5, C6, H2, H4, P4
No need to create one directory for each model.
Tested with C3, C6 (#17), H2.